### PR TITLE
Fix splitbelow comment

### DIFF
--- a/dot_vimrc
+++ b/dot_vimrc
@@ -123,7 +123,7 @@ set smartindent
 set autoindent
 
 
-set splitbelow  " open a new vertical split below
+set splitbelow  " open a new horizontal split below
 set splitright  " open a new horizontal split on the right
 
 


### PR DESCRIPTION
## Summary
- correct the comment describing `set splitbelow`

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a46af4264832f871f12bce0440739