### PR TITLE
Fix minor typo in dot_vimrc

### DIFF
--- a/dot_vimrc
+++ b/dot_vimrc
@@ -159,7 +159,7 @@ set incsearch
 """""""""""""""""""""""""""""""""""""
 " Mix
 """""""""""""""""""""""""""""""""""""
-" show the mathing brackets
+" show the matching brackets
 set showmatch
 set clipboard=unnamed
 


### PR DESCRIPTION
## Summary
- fix the comment for matching bracket highlighting

## Testing
- `grep -n "matching brackets" -n dot_vimrc`


------
https://chatgpt.com/codex/tasks/task_e_687a46ac851c832f81a38686eea70861